### PR TITLE
ObservableExtensions 클래스 추가

### DIFF
--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/CombineOperatorsTest.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/CombineOperatorsTest.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using FluentAssertions;
+using Ploeh.AutoFixture.Xunit2;
+using Xunit;
+
+namespace ReactiveMvvm.Tests
+{
+    public class CombineOperatorsTest
+    {
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
+        public void OrWith2ArgsReturnsCorrectValue(
+            bool arg1, bool arg2, bool expected)
+        {
+            CombineOperators.Or(arg1, arg2).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(true, true, true, true)]
+        [InlineData(true, true, false, true)]
+        [InlineData(true, false, true, true)]
+        [InlineData(true, false, false, true)]
+        [InlineData(false, true, true, true)]
+        [InlineData(false, true, false, true)]
+        [InlineData(false, false, true, true)]
+        [InlineData(false, false, false, false)]
+        public void OrWith3ArgsReturnsCorrectValue(
+            bool arg1, bool arg2, bool arg3, bool expected)
+        {
+            CombineOperators.Or(arg1, arg2, arg3).Should().Be(expected);
+        }
+
+        [Theory, AutoData]
+        public void OrWith4ArgsReturnsCorrectValue(
+            bool arg1, bool arg2, bool arg3, bool arg4)
+        {
+            CombineOperators.Or(arg1, arg2, arg3, arg4).Should()
+                .Be(arg1 || arg2 || arg3 || arg4);
+        }
+
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
+        public void AndWith2ArgsReturnsCorrectValue(
+            bool arg1, bool arg2, bool expected)
+        {
+            CombineOperators.And(arg1, arg2).Should().Be(expected);
+        }
+
+        [Theory]
+        [InlineData(true, true, true, true)]
+        [InlineData(true, true, false, false)]
+        [InlineData(true, false, true, false)]
+        [InlineData(true, false, false, false)]
+        [InlineData(false, true, true, false)]
+        [InlineData(false, true, false, false)]
+        [InlineData(false, false, true, false)]
+        [InlineData(false, false, false, false)]
+        public void AndWith3ArgsReturnsCorrectValue(
+            bool arg1, bool arg2, bool arg3, bool expected)
+        {
+            CombineOperators.And(arg1, arg2, arg3).Should().Be(expected);
+        }
+
+        [Theory, AutoData]
+        public void AndWith4ArgsReturnsCorrectValue(
+            bool arg1, bool arg2, bool arg3, bool arg4)
+        {
+            CombineOperators.And(arg1, arg2, arg3, arg4).Should()
+                .Be(arg1 && arg2 && arg3 && arg4);
+        }
+    }
+}

--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/CombineOperatorsTest.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/CombineOperatorsTest.cs
@@ -19,26 +19,26 @@ namespace ReactiveMvvm.Tests
         }
 
         [Theory]
-        [InlineData(true, true, true, true)]
-        [InlineData(true, true, false, true)]
-        [InlineData(true, false, true, true)]
-        [InlineData(true, false, false, true)]
-        [InlineData(false, true, true, true)]
-        [InlineData(false, true, false, true)]
-        [InlineData(false, false, true, true)]
-        [InlineData(false, false, false, false)]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
         public void OrWith3ArgsReturnsCorrectValue(
-            bool arg1, bool arg2, bool arg3, bool expected)
+            bool repeat, bool last, bool expected)
         {
-            CombineOperators.Or(arg1, arg2, arg3).Should().Be(expected);
+            CombineOperators.Or(repeat, repeat, last).Should().Be(expected);
         }
 
         [Theory, AutoData]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, true)]
+        [InlineData(false, true, true)]
+        [InlineData(false, false, false)]
         public void OrWith4ArgsReturnsCorrectValue(
-            bool arg1, bool arg2, bool arg3, bool arg4)
+            bool repeat, bool last, bool expected)
         {
-            CombineOperators.Or(arg1, arg2, arg3, arg4).Should()
-                .Be(arg1 || arg2 || arg3 || arg4);
+            CombineOperators.Or(repeat, repeat, repeat, last)
+                .Should().Be(expected);
         }
 
         [Theory]
@@ -53,26 +53,26 @@ namespace ReactiveMvvm.Tests
         }
 
         [Theory]
-        [InlineData(true, true, true, true)]
-        [InlineData(true, true, false, false)]
-        [InlineData(true, false, true, false)]
-        [InlineData(true, false, false, false)]
-        [InlineData(false, true, true, false)]
-        [InlineData(false, true, false, false)]
-        [InlineData(false, false, true, false)]
-        [InlineData(false, false, false, false)]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
         public void AndWith3ArgsReturnsCorrectValue(
-            bool arg1, bool arg2, bool arg3, bool expected)
+            bool repeat, bool last, bool expected)
         {
-            CombineOperators.And(arg1, arg2, arg3).Should().Be(expected);
+            CombineOperators.And(repeat, repeat, last).Should().Be(expected);
         }
 
-        [Theory, AutoData]
+        [Theory]
+        [InlineData(true, true, true)]
+        [InlineData(true, false, false)]
+        [InlineData(false, true, false)]
+        [InlineData(false, false, false)]
         public void AndWith4ArgsReturnsCorrectValue(
-            bool arg1, bool arg2, bool arg3, bool arg4)
+            bool repeat, bool last, bool expected)
         {
-            CombineOperators.And(arg1, arg2, arg3, arg4).Should()
-                .Be(arg1 && arg2 && arg3 && arg4);
+            CombineOperators.And(repeat, repeat, repeat, last)
+                .Should().Be(expected);
         }
     }
 }

--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/ObservableExtensionsTest.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/ObservableExtensionsTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using FluentAssertions;
+using Moq;
 using Ploeh.AutoFixture.Xunit2;
 using Xunit;
 
@@ -19,15 +20,17 @@ namespace ReactiveMvvm.Tests
         }
 
         [Theory, AutoData]
-        public void ObserveReturnsObservableForSpecifiedProperty(string value)
+        public void ObserveReturnsObservableForSpecifiedProperty(
+            string first, string second)
         {
-            var component = new Component();
-            string actual = null;
-            component.Observe(x => x.Foo)?.Subscribe(v => actual = v);
+            var component = new Component { Foo = first };
+            var functor = Mock.Of<IFunctor>();
+            component.Observe(x => x.Foo)?.Subscribe(functor.Action);
 
-            component.Foo = value;
+            component.Foo = second;
 
-            actual.Should().BeSameAs(value);
+            Mock.Get(functor).Verify(f => f.Action(first), Times.Once());
+            Mock.Get(functor).Verify(f => f.Action(second), Times.Once());
         }
 
         [Fact]

--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/ObservableExtensionsTest.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/ObservableExtensionsTest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using FluentAssertions;
+using Ploeh.AutoFixture.Xunit2;
+using Xunit;
+
+namespace ReactiveMvvm.Tests
+{
+    public class ObservableExtensionsTest
+    {
+        public class Component : ObservableObject
+        {
+            private string _foo;
+
+            public string Foo
+            {
+                get { return _foo; }
+                set { SetValue(ref _foo, value); }
+            }
+        }
+
+        [Theory, AutoData]
+        public void ObserveReturnsObservableForSpecifiedProperty(string value)
+        {
+            var component = new Component();
+            string actual = null;
+            component.Observe(x => x.Foo)?.Subscribe(v => actual = v);
+
+            component.Foo = value;
+
+            actual.Should().BeSameAs(value);
+        }
+
+        [Fact]
+        public void ObserveFailsWithInvalidExpression()
+        {
+            var component = new Component();
+            Action action = () => component.Observe(x => x.ToString());
+            action.ShouldThrow<ArgumentException>();
+        }
+    }
+}

--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/ObservableExtensionsTest.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/ObservableExtensionsTest.cs
@@ -23,11 +23,11 @@ namespace ReactiveMvvm.Tests
         public void ObserveReturnsObservableForSpecifiedProperty(
             string first, string second)
         {
-            var component = new Component { Foo = first };
+            var comp = new Component { Foo = first };
             var functor = Mock.Of<IFunctor>();
-            component.Observe(x => x.Foo)?.Subscribe(functor.Action);
+            comp.Observe(x => x.Foo)?.Subscribe(functor.Action);
 
-            component.Foo = second;
+            comp.Foo = second;
 
             Mock.Get(functor).Verify(f => f.Action(first), Times.Once());
             Mock.Get(functor).Verify(f => f.Action(second), Times.Once());
@@ -39,6 +39,20 @@ namespace ReactiveMvvm.Tests
             var component = new Component();
             Action action = () => component.Observe(x => x.ToString());
             action.ShouldThrow<ArgumentException>();
+        }
+
+        [Theory, AutoData]
+        public void ObserveReturnsObservableOfProjectionForSpecifiedProperty()
+        {
+            var comp = new Component { Foo = string.Empty };
+            var functor = Mock.Of<IFunctor>();
+            comp.Observe(x => x.Foo, s => string.IsNullOrWhiteSpace(s))?
+                .Subscribe(functor.Action);
+
+            comp.Foo = "Hello World";
+
+            Mock.Get(functor).Verify(f => f.Action(true), Times.Once());
+            Mock.Get(functor).Verify(f => f.Action(false), Times.Once());
         }
     }
 }

--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/ReactiveCommandTest.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/ReactiveCommandTest.cs
@@ -70,6 +70,23 @@ namespace ReactiveMvvm.Tests
         }
 
         [Theory, AutoData]
+        public void InitializesCanExecuteValueSourceAndSyncExecuteAction(
+            object parameter)
+        {
+            var canExecuteSource = new BehaviorSubject<bool>(true);
+            var functor = Mock.Of<IFunctor>();
+
+            var command = ReactiveCommand.Create(
+                canExecuteSource, p => functor.Action(p));
+            command?.Execute(parameter);
+            canExecuteSource.OnNext(false);
+
+            command.Should().NotBeNull();
+            command.CanExecute(parameter).Should().BeFalse();
+            Mock.Get(functor).Verify(f => f.Action(parameter), Times.Once());
+        }
+
+        [Theory, AutoData]
         public void InitializesWithSyncExecuteFunc(object parameter)
         {
             var functor = Mock.Of<IFunctor>();

--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/ReactiveMvvm.Tests.csproj
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/ReactiveMvvm.Tests.csproj
@@ -105,6 +105,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="ClearStreamAfterTestAttribute.cs" />
+    <Compile Include="CombineOperatorsTest.cs" />
     <Compile Include="DefaultCoalescerTest.cs" />
     <Compile Include="IFunctor.cs" />
     <Compile Include="ModelTest.cs" />

--- a/src/ReactiveMvvm/ReactiveMvvm.Tests/ReactiveMvvm.Tests.csproj
+++ b/src/ReactiveMvvm/ReactiveMvvm.Tests/ReactiveMvvm.Tests.csproj
@@ -108,6 +108,7 @@
     <Compile Include="DefaultCoalescerTest.cs" />
     <Compile Include="IFunctor.cs" />
     <Compile Include="ModelTest.cs" />
+    <Compile Include="ObservableExtensionsTest.cs" />
     <Compile Include="ReactiveCommandTest.cs" />
     <Compile Include="StreamExtensionsTest.cs" />
     <Compile Include="StreamTest.cs" />

--- a/src/ReactiveMvvm/ReactiveMvvm/CombineOperators.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm/CombineOperators.cs
@@ -12,19 +12,19 @@ namespace ReactiveMvvm
         public static bool Or(bool arg1, bool arg2) => arg1 || arg2;
 
         public static bool Or(bool arg1, bool arg2, bool arg3)
-            => arg1 || arg2 || arg3;
+            => Or(arg1, arg2) || arg3;
 
         [SuppressMessage("Microsoft.Design", "CA1025:ReplaceRepetitiveArgumentsWithParamsArray", Justification = "The purpose of this method is to use to Observable.CombineLatest() method as 'resultSelector' parameter")]
         public static bool Or(bool arg1, bool arg2, bool arg3, bool arg4)
-            => arg1 || arg2 || arg3 || arg4;
+            => Or(arg1, arg2, arg3) || arg4;
 
         public static bool And(bool arg1, bool arg2) => arg1 && arg2;
 
         public static bool And(bool arg1, bool arg2, bool arg3)
-            => arg1 && arg2 && arg3;
+            => And(arg1, arg2) && arg3;
 
         [SuppressMessage("Microsoft.Design", "CA1025:ReplaceRepetitiveArgumentsWithParamsArray", Justification = "The purpose of this method is to use to Observable.CombineLatest() method as 'resultSelector' parameter")]
         public static bool And(bool arg1, bool arg2, bool arg3, bool arg4)
-            => arg1 && arg2 && arg3 && arg4;
+            => And(arg1, arg2, arg3) && arg4;
     }
 }

--- a/src/ReactiveMvvm/ReactiveMvvm/CombineOperators.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm/CombineOperators.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace ReactiveMvvm
 {
@@ -13,6 +14,7 @@ namespace ReactiveMvvm
         public static bool Or(bool arg1, bool arg2, bool arg3)
             => arg1 || arg2 || arg3;
 
+        [SuppressMessage("Microsoft.Design", "CA1025:ReplaceRepetitiveArgumentsWithParamsArray", Justification = "The purpose of this method is to use to Observable.CombineLatest() method as 'resultSelector' parameter")]
         public static bool Or(bool arg1, bool arg2, bool arg3, bool arg4)
             => arg1 || arg2 || arg3 || arg4;
 
@@ -21,6 +23,7 @@ namespace ReactiveMvvm
         public static bool And(bool arg1, bool arg2, bool arg3)
             => arg1 && arg2 && arg3;
 
+        [SuppressMessage("Microsoft.Design", "CA1025:ReplaceRepetitiveArgumentsWithParamsArray", Justification = "The purpose of this method is to use to Observable.CombineLatest() method as 'resultSelector' parameter")]
         public static bool And(bool arg1, bool arg2, bool arg3, bool arg4)
             => arg1 && arg2 && arg3 && arg4;
     }

--- a/src/ReactiveMvvm/ReactiveMvvm/CombineOperators.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm/CombineOperators.cs
@@ -1,0 +1,27 @@
+﻿using System;
+
+namespace ReactiveMvvm
+{
+    // TODO: CombineOperators 클래스 디자인이 성숙단계에 이르면
+    // XML 주석을 추가하고 아래 pragma 지시문을 삭제합니다.
+#pragma warning disable CS1591
+
+    public static class CombineOperators
+    {
+        public static bool Or(bool arg1, bool arg2) => arg1 || arg2;
+
+        public static bool Or(bool arg1, bool arg2, bool arg3)
+            => arg1 || arg2 || arg3;
+
+        public static bool Or(bool arg1, bool arg2, bool arg3, bool arg4)
+            => arg1 || arg2 || arg3 || arg4;
+
+        public static bool And(bool arg1, bool arg2) => arg1 && arg2;
+
+        public static bool And(bool arg1, bool arg2, bool arg3)
+            => arg1 && arg2 && arg3;
+
+        public static bool And(bool arg1, bool arg2, bool arg3, bool arg4)
+            => arg1 && arg2 && arg3 && arg4;
+    }
+}

--- a/src/ReactiveMvvm/ReactiveMvvm/ObservableExtensions.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm/ObservableExtensions.cs
@@ -31,6 +31,32 @@ namespace ReactiveMvvm
             return null;
         }
 
+        private static IObservable<TProperty> ObserveImpl
+            <TComponent, TProperty>(
+            TComponent component,
+            Expression<Func<TComponent, TProperty>> propertyExpression)
+            where TComponent : INotifyPropertyChanged
+        {
+            var propertyName = GetMemberName(propertyExpression.Body);
+            if (propertyName == null)
+            {
+                throw new ArgumentException(
+                    "The expression is not a property expression.",
+                    paramName: nameof(propertyExpression));
+            }
+
+            var compiled = propertyExpression.Compile();
+
+            var source = Observable.FromEventPattern<PropertyChangedEventArgs>(
+                component, nameof(component.PropertyChanged));
+
+            return Observable
+                .Start(() => compiled.Invoke(component))
+                .Concat(from e in source
+                        where e.EventArgs.PropertyName == propertyName
+                        select compiled.Invoke(component));
+        }
+
         /// <summary>
         /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체의
         /// 지정한 속성을 관찰합니다.
@@ -40,7 +66,8 @@ namespace ReactiveMvvm
         /// </typeparam>
         /// <typeparam name="TProperty">관찰할 속성의 형식입니다.</typeparam>
         /// <param name="component"><see cref="INotifyPropertyChanged"/>
-        /// 인터페이스 구현체입니다.</param>
+        /// 인터페이스 구현체입니다.
+        /// </param>
         /// <param name="propertyExpression">
         /// 관찰할 속성을 표현하는 식입니다.
         /// </param>
@@ -65,24 +92,53 @@ namespace ReactiveMvvm
                 throw new ArgumentNullException(nameof(propertyExpression));
             }
 
-            var propertyName = GetMemberName(propertyExpression.Body);
-            if (propertyName == null)
+            return ObserveImpl(component, propertyExpression);
+        }
+
+        /// <summary>
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체의
+        /// 지정한 속성의 투영 값을 관찰합니다.
+        /// </summary>
+        /// <typeparam name="TComponent">
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체 형식입니다.
+        /// </typeparam>
+        /// <typeparam name="TProperty">관찰할 속성의 형식입니다.</typeparam>
+        /// <typeparam name="TResult">속성 투영 값 형식입니다.</typeparam>
+        /// <param name="component"><see cref="INotifyPropertyChanged"/>
+        /// 인터페이스 구현체입니다.
+        /// </param>
+        /// <param name="propertyExpression">
+        /// 관찰할 속성을 표현하는 식입니다.
+        /// </param>
+        /// <param name="selector">속성 값을 투영하는 함수입니다.</param>
+        /// <returns>
+        /// <paramref name="propertyExpression"/>이 표현하는 속성 값의
+        /// 투영 결과를 노출하는 <see cref="IObservable{T}"/>입니다.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// 매개변수 propertyExpression이 올바른 속성 표현식이 아닌 경우
+        /// </exception>
+        public static IObservable<TResult> Observe
+            <TComponent, TProperty, TResult>(
+            this TComponent component,
+            Expression<Func<TComponent, TProperty>> propertyExpression,
+            Func<TProperty, TResult> selector)
+            where TComponent : INotifyPropertyChanged
+        {
+            if (component == null)
             {
-                throw new ArgumentException(
-                    "The expression is not a property expression.",
-                    paramName: nameof(propertyExpression));
+                throw new ArgumentNullException(nameof(component));
+            }
+            if (propertyExpression == null)
+            {
+                throw new ArgumentNullException(nameof(propertyExpression));
+            }
+            if (selector == null)
+            {
+                throw new ArgumentNullException(nameof(selector));
             }
 
-            var compiled = propertyExpression.Compile();
-
-            var source = Observable.FromEventPattern<PropertyChangedEventArgs>(
-                component, nameof(component.PropertyChanged));
-
-            return Observable
-                .Start(() => compiled.Invoke(component))
-                .Concat(from e in source
-                        where e.EventArgs.PropertyName == propertyName
-                        select compiled.Invoke(component));
+            return ObserveImpl(component, propertyExpression).Select(selector);
         }
     }
 }

--- a/src/ReactiveMvvm/ReactiveMvvm/ObservableExtensions.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm/ObservableExtensions.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq.Expressions;
+using System.Reactive.Linq;
+
+namespace ReactiveMvvm
+{
+    /// <summary>
+    /// <see cref="IObservable{T}"/> 인터페이스와
+    /// <see cref="INotifyPropertyChanged"/> 인터페이스를 지원하는
+    /// 메서드 집합을 제공합니다.
+    /// </summary>
+    public static class ObservableExtensions
+    {
+        private static string GetMemberName(Expression expression)
+        {
+            var body = expression as MemberExpression;
+            if (body != null)
+            {
+                return body.Member.Name;
+            }
+            if (expression.NodeType == ExpressionType.Convert)
+            {
+                var unaryExpression = expression as UnaryExpression;
+                body = unaryExpression.Operand as MemberExpression;
+                if (body != null)
+                {
+                    return body.Member.Name;
+                }
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체의
+        /// 지정한 속성을 관찰합니다.
+        /// </summary>
+        /// <typeparam name="TComponent">
+        /// <see cref="INotifyPropertyChanged"/> 인터페이스 구현체 형식입니다.
+        /// </typeparam>
+        /// <typeparam name="TProperty">관찰할 속성의 형식입니다.</typeparam>
+        /// <param name="component"><see cref="INotifyPropertyChanged"/>
+        /// 인터페이스 구현체입니다.</param>
+        /// <param name="propertyExpression">
+        /// 관찰할 속성을 표현하는 식입니다.
+        /// </param>
+        /// <returns>
+        /// <paramref name="propertyExpression"/>이 표현하는 속성 값의
+        /// 변화를 노출하는 <see cref="IObservable{T}"/>입니다.
+        /// </returns>
+        /// <exception cref="ArgumentException">
+        /// 매개변수 propertyExpression이 올바른 속성 표현식이 아닌 경우
+        /// </exception>
+        public static IObservable<TProperty> Observe<TComponent, TProperty>(
+            this TComponent component,
+            Expression<Func<TComponent, TProperty>> propertyExpression)
+            where TComponent : INotifyPropertyChanged
+        {
+            if (component == null)
+            {
+                throw new ArgumentNullException(nameof(component));
+            }
+            if (propertyExpression == null)
+            {
+                throw new ArgumentNullException(nameof(propertyExpression));
+            }
+
+            var propertyName = GetMemberName(propertyExpression.Body);
+            if (propertyName == null)
+            {
+                throw new ArgumentException(
+                    "The expression is not a property expression.",
+                    paramName: nameof(propertyExpression));
+            }
+
+            var compiled = propertyExpression.Compile();
+            var source = Observable.FromEventPattern<PropertyChangedEventArgs>(
+                component, nameof(component.PropertyChanged));
+            return from e in source
+                   where e.EventArgs.PropertyName == propertyName
+                   select compiled.Invoke(component);
+        }
+    }
+}

--- a/src/ReactiveMvvm/ReactiveMvvm/ObservableExtensions.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm/ObservableExtensions.cs
@@ -74,11 +74,15 @@ namespace ReactiveMvvm
             }
 
             var compiled = propertyExpression.Compile();
+
             var source = Observable.FromEventPattern<PropertyChangedEventArgs>(
                 component, nameof(component.PropertyChanged));
-            return from e in source
-                   where e.EventArgs.PropertyName == propertyName
-                   select compiled.Invoke(component);
+
+            return Observable
+                .Start(() => compiled.Invoke(component))
+                .Concat(from e in source
+                        where e.EventArgs.PropertyName == propertyName
+                        select compiled.Invoke(component));
         }
     }
 }

--- a/src/ReactiveMvvm/ReactiveMvvm/ReactiveCommand.cs
+++ b/src/ReactiveMvvm/ReactiveMvvm/ReactiveCommand.cs
@@ -36,6 +36,27 @@ namespace ReactiveMvvm
                 });
         }
 
+        public static ReactiveCommand<Unit> Create(
+            IObservable<bool> canExecuteSource, Action<object> execute)
+        {
+            if (canExecuteSource == null)
+            {
+                throw new ArgumentNullException(nameof(canExecuteSource));
+            }
+            if (execute == null)
+            {
+                throw new ArgumentNullException(nameof(execute));
+            }
+
+            return new ReactiveCommand<Unit>(
+                canExecuteSource.Select(e => (Func<object, bool>)(_ => e)),
+                p =>
+                {
+                    execute.Invoke(p);
+                    return Task.FromResult(Unit.Default);
+                });
+        }
+
         public static ReactiveCommand<T> Create<T>(Func<object, T> execute)
         {
             if (execute == null)

--- a/src/ReactiveMvvm/ReactiveMvvm/ReactiveMvvm.csproj
+++ b/src/ReactiveMvvm/ReactiveMvvm/ReactiveMvvm.csproj
@@ -45,6 +45,7 @@
     <Compile Include="ICoalescer.cs" />
     <Compile Include="IModel.cs" />
     <Compile Include="Model.cs" />
+    <Compile Include="ObservableExtensions.cs" />
     <Compile Include="ReactiveCommand.cs" />
     <Compile Include="Stream.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/src/ReactiveMvvm/ReactiveMvvm/ReactiveMvvm.csproj
+++ b/src/ReactiveMvvm/ReactiveMvvm/ReactiveMvvm.csproj
@@ -39,6 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Coalescer.cs" />
+    <Compile Include="CombineOperators.cs" />
     <Compile Include="DefaultCoalescer.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ICoalescable.cs" />

--- a/src/ReactiveMvvm/Samples/UserManager/UserManager.csproj
+++ b/src/ReactiveMvvm/Samples/UserManager/UserManager.csproj
@@ -53,6 +53,10 @@
       <HintPath>..\..\packages\Rx-PlatformServices.2.2.5\lib\net45\System.Reactive.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Reactive.Windows.Threading, Version=2.2.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Rx-XAML.2.2.5\lib\net45\System.Reactive.Windows.Threading.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />

--- a/src/ReactiveMvvm/Samples/UserManager/packages.config
+++ b/src/ReactiveMvvm/Samples/UserManager/packages.config
@@ -3,5 +3,8 @@
   <package id="Rx-Core" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Interfaces" version="2.2.5" targetFramework="net452" />
   <package id="Rx-Linq" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-Main" version="2.2.5" targetFramework="net452" />
   <package id="Rx-PlatformServices" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-WPF" version="2.2.5" targetFramework="net452" />
+  <package id="Rx-XAML" version="2.2.5" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
`INotifyPropertyChanged`인터페이스 구현체를 지원하는 `ObservableExtensions` 클래스를 추가합니다.
관찰 가능한 개체의 특정 속성에 대한 `IObservable<T>`를 만들어 줍니다.

This resolves #34 