### PR TITLE
ReactiveViewModel<, >.Model 속성 변경 이벤트가 하나의 데이터 인스턴스를 사용하도록 합니다. #46

### DIFF
--- a/src/ReactiveMvvm/ViewModels/ReactiveViewModel.cs
+++ b/src/ReactiveMvvm/ViewModels/ReactiveViewModel.cs
@@ -1,7 +1,14 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace ReactiveMvvm.ViewModels
 {
+    public static class ReactiveViewModel
+    {
+        public static PropertyChangedEventArgs ModelChangedEventArgs
+            { get; } = new PropertyChangedEventArgs("Model");
+    }
+
     // TODO: ReactiveViewModel<TModel, TId> 클래스에 XML 주석이 작성되면 pragam
     // 지시문을 삭제해주세요.
 #pragma warning disable 1591
@@ -45,8 +52,19 @@ namespace ReactiveMvvm.ViewModels
 
         public TModel Model
         {
-            get { return _model; }
-            private set { SetValue(ref _model, value); }
+            get
+            {
+                return _model;
+            }
+            private set
+            {
+                if (Equals(_model, value))
+                {
+                    return;
+                }
+                _model = value;
+                OnPropertyChanged(ReactiveViewModel.ModelChangedEventArgs);
+            }
         }
 
         public void Dispose()

--- a/test/ReactiveMvvm.Tests/ViewModels/ReactiveViewModelTest.cs
+++ b/test/ReactiveMvvm.Tests/ViewModels/ReactiveViewModelTest.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Reactive.Linq;
+using System.ComponentModel;
 using FluentAssertions;
 using Ploeh.AutoFixture.Xunit2;
 using ReactiveMvvm.ViewModels;
@@ -28,10 +28,24 @@ namespace ReactiveMvvm.Tests.ViewModels
             var sut = new ReactiveViewModel<User, string>(user.Id);
             sut.MonitorEvents();
 
-            stream.OnNext(Observable.Return(user));
+            stream.OnNext(user);
 
             sut.Model.Should().BeSameAs(user);
             sut.ShouldRaisePropertyChangeFor(x => x.Model);
+        }
+
+        [Theory, AutoData]
+        public void ModelSetterRaisesEventWithModelChangedEventArgs(User user)
+        {
+            var stream = Stream<User, string>.Get(user.Id);
+            var sut = new ReactiveViewModel<User, string>(user.Id);
+            sut.MonitorEvents();
+
+            stream.OnNext(user);
+
+            sut.ShouldRaisePropertyChangeFor(x => x.Model)
+                .WithArgs<PropertyChangedEventArgs>(args => ReferenceEquals(
+                    args, ReactiveViewModel.ModelChangedEventArgs));
         }
     }
 }


### PR DESCRIPTION
This resolves #46 